### PR TITLE
Use higher version of Ubuntu for CICD

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   build_and_push_docker_images:
     name: Build and Push Docker Images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Set DOCKER_PUSH env var
         run: |


### PR DESCRIPTION
Use ubuntu-22.04 as the current image in the CICD has been banned by GitHub